### PR TITLE
Connection management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,24 @@ import { AppScenario } from "webnative"
 
 // Initialise
 
-const appState = await walletauth.app()
+const initialAppState = await walletauth.app({
+  // optional event handlers
+  onAccountChange: (newAppState) => handleAppState(newAppState),
+  onDisconnect: () => { /* eg. logout() */ }
+})
 
-switch (appState.scenario) {
-  case AppScenario.Authed:
-    // ✅ Authenticated
-    break;
+handleAppState(initialAppState)
 
-  case AppScenario.NotAuthed:
-    // Failed to authenticate with wallet
-    break;
+function handleAppState(appState) {
+  switch (appState.scenario) {
+    case AppScenario.Authed:
+      // ✅ Authenticated
+      break;
+
+    case AppScenario.NotAuthed:
+      // Failed to authenticate with wallet
+      break;
+  }
 }
 ```
 
@@ -31,7 +39,7 @@ import * as ethereum from "webnative-walletauth/wallet/ethereum.ts"
 ethereum.setProvider(window.ethereum)
 ```
 
-**You can also write an implementation for other wallets.** Note that the DID method has to be supported by the [Fission server](https://github.com/fission-codes/fission), unless you're using something else with webnative. At the moment of writing, you can only use the `key` method for DIDs with the Fission servers. It supports ED25519, RSA and SECP256K1 keys.
+**You can also write an implementation for other wallets.** Note that the DID method has to be supported by the [Fission server](https://github.com/fission-codes/fission), unless you're using something else with webnative. At the moment of writing, you can only use the `key` method for DIDs with the Fission servers. It supports ED25519, RSA and SECP256K1 keys, same for the UCAN algorithms.
 
 ```ts
 import * as walletImpl from "webnative-walletauth/wallet/implementation.ts"
@@ -42,6 +50,7 @@ const impl: Implementation = {
   decrypt:              (encryptedMessage: Uint8Array) => Promise<Uint8Array>,
   did:                  () => Promise<string>,
   encrypt:              (data: Uint8Array) => Promise<Uint8Array>,
+  init:                 () => Promise<void>,
   sign:                 (data: Uint8Array) => Promise<Uint8Array>,
   ucanAlgorithm:        string,
   username:             () => Promise<string>,

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ import { Implementation } from "webnative-walletauth/wallet/types.ts"
 
 
 const impl: Implementation = {
-  decrypt:              () => Promise.resolve(...),
-  did:                  () => Promise.resolve(...),
-  encrypt:              () => Promise.resolve(...),
-  sign:                 () => Promise.resolve(...),
-  username:             () => Promise.resolve(...),
-  verifySignedMessage:  () => Promise.resolve(...),
+  decrypt:              (encryptedMessage: Uint8Array) => Promise<Uint8Array>,
+  did:                  () => Promise<string>,
+  encrypt:              (data: Uint8Array) => Promise<Uint8Array>,
+  sign:                 (data: Uint8Array) => Promise<Uint8Array>,
+  ucanAlgorithm:        string,
+  username:             () => Promise<string>,
+  verifySignedMessage:  (args: { signature: Uint8Array; message: Uint8Array; publicKey?: Uint8Array }) => Promise<boolean>,
 }
 
 // NOTE: run this before you call `walletAuth.app()`

--- a/package.json
+++ b/package.json
@@ -49,13 +49,15 @@
     "url": "https://github.com/fission-codes/webnative-walletauth/issues"
   },
   "homepage": "https://github.com/fission-codes/webnative-walletauth#readme",
+  "peerDependencies": {
+    "webnative": "^0.34.1"
+  },
   "dependencies": {
     "@noble/hashes": "^1.1.2",
     "@noble/secp256k1": "^1.6.3",
     "eip1193-provider": "^1.0.1",
     "tweetnacl": "^1.0.3",
-    "uint8arrays": "^3.1.0",
-    "webnative": "^0.34.1"
+    "uint8arrays": "^3.1.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.10.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,11 @@ export async function app(options?: { resetWnfs?: boolean; useWnfs?: boolean }):
   const username = await wallet.username()
   const isNewUser = await isUsernameAvailable(username) === true
 
-  if (resetWnfs || isNewUser) await leave({ withoutRedirect: true })
-  const authedUsername = await authenticatedUsername()
+  let authedUsername = await authenticatedUsername()
+  if (resetWnfs || isNewUser || username !== authedUsername) {
+    await leave({ withoutRedirect: true })
+    authedUsername = null
+  }
 
   // Ensure UCAN store
   await ucanInternal.store([])

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -29,7 +29,7 @@ export async function build({
   const currentTimeInSeconds = Math.floor(Date.now() / 1000)
 
   const header = {
-    alg: "ES256K",
+    alg: wallet.ucanAlgorithm(),
     typ: "JWT",
     uav: "1.0.0"
   }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,10 +1,12 @@
 import { impl } from "./wallet/implementation"
+import { InitArgs, VerifyArgs } from "./wallet/types"
 
 
 export const decrypt = (encryptedMessage: Uint8Array) => impl.decrypt(encryptedMessage)
 export const did = () => impl.did()
 export const encrypt = (data: Uint8Array) => impl.encrypt(data)
+export const init = (args: InitArgs) => impl.init(args)
 export const sign = (data: Uint8Array) => impl.sign(data)
 export const ucanAlgorithm = () => impl.ucanAlgorithm
 export const username = () => impl.username()
-export const verifySignedMessage = (args: { signature: Uint8Array; message: Uint8Array; publicKey?: Uint8Array }) => impl.verifySignedMessage(args)
+export const verifySignedMessage = (args: VerifyArgs) => impl.verifySignedMessage(args)

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -5,5 +5,6 @@ export const decrypt = (encryptedMessage: Uint8Array) => impl.decrypt(encryptedM
 export const did = () => impl.did()
 export const encrypt = (data: Uint8Array) => impl.encrypt(data)
 export const sign = (data: Uint8Array) => impl.sign(data)
+export const ucanAlgorithm = () => impl.ucanAlgorithm
 export const username = () => impl.username()
 export const verifySignedMessage = (args: { signature: Uint8Array; message: Uint8Array; publicKey?: Uint8Array }) => impl.verifySignedMessage(args)

--- a/src/wallet/ethereum.ts
+++ b/src/wallet/ethereum.ts
@@ -365,6 +365,7 @@ export const implementation: Implementation = {
   encrypt,
   did,
   sign,
+  ucanAlgorithm: "ES256K",
   username,
   verifySignedMessage,
 }

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -2,8 +2,22 @@ export type Implementation = {
   decrypt: (encryptedMessage: Uint8Array) => Promise<Uint8Array>
   did: () => Promise<string>
   encrypt: (data: Uint8Array) => Promise<Uint8Array>
+  init: (args: InitArgs) => Promise<void>
   sign: (data: Uint8Array) => Promise<Uint8Array>
   ucanAlgorithm: string
   username: () => Promise<string>
-  verifySignedMessage: (args: { signature: Uint8Array; message: Uint8Array; publicKey?: Uint8Array }) => Promise<boolean>
+  verifySignedMessage: (args: VerifyArgs) => Promise<boolean>
+}
+
+
+export type InitArgs = {
+  onAccountChange: () => Promise<unknown>;
+  onDisconnect: () => Promise<unknown>;
+}
+
+
+export type VerifyArgs = {
+  signature: Uint8Array;
+  message: Uint8Array;
+  publicKey?: Uint8Array;
 }

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -1,8 +1,9 @@
 export type Implementation = {
-  decrypt(encryptedMessage: Uint8Array): Promise<Uint8Array>
+  decrypt: (encryptedMessage: Uint8Array) => Promise<Uint8Array>
   did: () => Promise<string>
-  encrypt(data: Uint8Array): Promise<Uint8Array>
+  encrypt: (data: Uint8Array) => Promise<Uint8Array>
   sign: (data: Uint8Array) => Promise<Uint8Array>
+  ucanAlgorithm: string
   username: () => Promise<string>
   verifySignedMessage: (args: { signature: Uint8Array; message: Uint8Array; publicKey?: Uint8Array }) => Promise<boolean>
 }


### PR DESCRIPTION
Connection management changes:
- New `init` function for the wallet implementation, here's where the `accountChanged` ethereum-provider event is handled.
- When people call the entry point `.app()` from the index.ts file, it'll call this new `init` function, passing in callbacks that will log out the current user when the Ethereum account changes or disconnects. And it'll re-authenticate automatically on account change.
- Optionally people can pass in `onAccountChange` and `onDisconnect` event handlers as options to `app()`. See example in the README.

Other changes:
- Makes `webnative` a peer dependency.
- Made the UCAN algorithm a wallet implementation detail
- README improvements