### PR TITLE
Avivash/multiple metamask popups

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,10 @@ export const READ_KEY_PATH = path.file(path.Branch.Public, ".well-known", "read-
 
 
 export type AppOptions = {
-  onAccountChange?: (appState: AppState) => unknown;
-  onDisconnect?: Function;
-  resetWnfs?: boolean;
-  useWnfs?: boolean;
+  onAccountChange?: (appState: AppState) => unknown
+  onDisconnect?: (...args: unknown[]) => unknown
+  resetWnfs?: boolean
+  useWnfs?: boolean
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,16 +68,6 @@ export async function app(options?: AppOptions): Promise<AppState> {
   if (hasProp(self, "isSecureContext") && self.isSecureContext === false) throw InitialisationError.InsecureContext
   if (await isSupported() === false) throw InitialisationError.UnsupportedBrowser
 
-  // Initialise wallet
-  await wallet.init({
-    onAccountChange: () => leave({ withoutRedirect: true })
-      .then(() => app(options))
-      .then(a => options?.onAccountChange ? options.onAccountChange(a) : a),
-
-    onDisconnect: () => leave({ withoutRedirect: true })
-      .then(a => options?.onDisconnect ? options.onDisconnect(a) : a),
-  })
-
   // Authenticate & create user if necessary
   const username = await wallet.username()
   const isNewUser = await isUsernameAvailable(username) === true
@@ -87,6 +77,16 @@ export async function app(options?: AppOptions): Promise<AppState> {
     await leave({ withoutRedirect: true })
     authedUsername = null
   }
+
+  // Initialise wallet
+  await wallet.init({
+    onAccountChange: () => leave({ withoutRedirect: true })
+      .then(() => app(options))
+      .then(a => options?.onAccountChange ? options.onAccountChange(a) : a),
+
+    onDisconnect: () => leave({ withoutRedirect: true })
+      .then(a => options?.onDisconnect ? options.onDisconnect(a) : a),
+  })
 
   // Ensure UCAN store
   await ucanInternal.store([])

--- a/src/wallet/ethereum.ts
+++ b/src/wallet/ethereum.ts
@@ -37,7 +37,6 @@ let didBindEvents = false
 let globCurrentAccount: string | null = null
 let globPublicEncryptionKey: Uint8Array | null = null
 let globPublicSignatureKey: Uint8Array | null = null
-const globSignature: { [key: string]: Uint8Array } = {}
 let provider: Provider | null = hasProp(self, "ethereum") ? self.ethereum as Provider : null
 
 
@@ -155,12 +154,9 @@ export async function init({ onAccountChange, onDisconnect }: InitArgs): Promise
 
 
 export async function sign(data: Uint8Array): Promise<Uint8Array> {
-  const key = `${globCurrentAccount}-${data.toString()}`
-  if (globSignature[key]) return globSignature[key]
-
   const provider = await load()
 
-  const signature = await provider.request({
+  return provider.request({
     method: "personal_sign", params: [
       uint8ArrayToEthereumHex(data),
       await address(),
@@ -172,10 +168,6 @@ export async function sign(data: Uint8Array): Promise<Uint8Array> {
       else throw new Error("Expected the result of `sign` to be a hexadecimal string")
     })
     .then(uint8ArrayFromEthereumHex)
-
-  globSignature[key] = signature
-
-  return signature
 }
 
 

--- a/src/wallet/ethereum.ts
+++ b/src/wallet/ethereum.ts
@@ -33,7 +33,7 @@ export const SECP_PREFIX = new Uint8Array([ 0xe7, 0x01 ])
 // 🌸
 
 
-let didBindEvents: boolean = false
+let didBindEvents = false
 let globCurrentAccount: string | null = null
 let globPublicEncryptionKey: Uint8Array | null = null
 let globPublicSignatureKey: Uint8Array | null = null

--- a/src/wallet/ethereum.ts
+++ b/src/wallet/ethereum.ts
@@ -132,8 +132,8 @@ export async function init({ onAccountChange, onDisconnect }: InitArgs): Promise
   // which will return an empty accounts array
   ethereum.on("accountsChanged", async (accounts: string[]) => {
     if (accounts.length) {
-      // MetaMask can sometimes trigger accountsChanged when first connecting to an account, so we
-      // need to ensure it is actually being triggered by a new account change to extra signatures
+      // MetaMask can sometimes trigger accountsChanged when first connecting to an account, so we need to
+      // ensure it is actually being triggered by a new account change to avoid extra signatures
       if (globCurrentAccount !== accounts[0]) {
         handleAccountsChanged(accounts)
         await onAccountChange()

--- a/src/wallet/ethereum.ts
+++ b/src/wallet/ethereum.ts
@@ -154,16 +154,6 @@ export async function init({ onAccountChange, onDisconnect }: InitArgs): Promise
 }
 
 
-async function disconnect({
-  onDisconnect,
-}: {
-  onDisconnect: () => Promise<unknown>
-}): Promise<void> {
-  globCurrentAccount = null
-  await onDisconnect()
-}
-
-
 export async function sign(data: Uint8Array): Promise<Uint8Array> {
   const key = `${globCurrentAccount}-${data.toString()}`
   if (globSignature[key]) return globSignature[key]
@@ -280,6 +270,16 @@ export async function publicSignatureKey(): Promise<Uint8Array> {
   )
 
   return globPublicSignatureKey
+}
+
+
+async function disconnect({
+  onDisconnect,
+}: {
+  onDisconnect: () => Promise<unknown>
+}): Promise<void> {
+  globCurrentAccount = null
+  await onDisconnect()
 }
 
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -11,13 +11,13 @@ export type Implementation = {
 
 
 export type InitArgs = {
-  onAccountChange: () => Promise<unknown>;
-  onDisconnect: () => Promise<unknown>;
+  onAccountChange: () => Promise<unknown>
+  onDisconnect: () => Promise<unknown>
 }
 
 
 export type VerifyArgs = {
-  signature: Uint8Array;
-  message: Uint8Array;
-  publicKey?: Uint8Array;
+  signature: Uint8Array
+  message: Uint8Array
+  publicKey?: Uint8Array
 }


### PR DESCRIPTION
# Description

There was an issue where [walletauth.app](https://github.com/fission-codes/webnative-walletauth/blob/avivash/multiple-metamask-popups/src/index.ts#L58) was sometimes being called twice when a user first connected their wallet client to the site. This was because the `accountsChanged` event was being subscribed to within `walletauth.app`(when it calls [walletauth.init](https://github.com/fission-codes/webnative-walletauth/compare/avivash/multiple-metamask-popups?expand=1#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R83)) then triggered by MetaMask when a wallet was first connected during the execution of the `app` function. To get around this I added a check to the [accountsChanged](https://github.com/fission-codes/webnative-walletauth/compare/avivash/multiple-metamask-popups?expand=1#diff-ec9cbbd54cdf6e719b88a297f273ddf7199ef63b870eaab16afd27e066c94622R137) hook to see if the updated account differed from the current account and only allow the function to execute when that condition was met.

Additionally, I had to move the [walletauth.init](https://github.com/fission-codes/webnative-walletauth/compare/avivash/multiple-metamask-popups?expand=1#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R82) call below the [wallet.username](https://github.com/fission-codes/webnative-walletauth/compare/avivash/multiple-metamask-popups?expand=1#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R72) call to ensure the username(account) was set before `accountsChanged` was subscribed to.

I noticed we have a decent amount of places in the app that call `sign(MSG_TO_SIGN)` too, so I figured it wouldn't hurt to cache those results using a key of `${globCurrentAccount}-${data.toString()}`, though admittedly `data.toString()` can produce a fairly long string, but I haven't noticed any issues with it yet 😅 

Also, to answer your question about the `disconnect` event @icidasset:
> Disconnecting an account triggers an "accountChanged" event, even though there's no other accounts connected. Not sure why Metamask isn't issuing a "disconnected" event here 🤔

It seems `disconnect` is only triggered when MetaMask has a network error and can't submit RPC requests https://docs.metamask.io/guide/ethereum-provider.html#disconnect. To actually detect if a user has disconnected, we need to have a check in the `accountsChanged` hook that checks if the `accounts` array is empty, [so I've added that](https://github.com/fission-codes/webnative-walletauth/blob/avivash/multiple-metamask-popups/src/wallet/ethereum.ts#L149-L164)  👌🏼 

Also, [I made a small change to the svelte app](https://github.com/webnative-examples/walletauth/blob/main/src/lib/session.ts#L34) to ensure the `disconnect` callback is called when walletauth detects a disconnection 👍🏼 

## Link to issue

https://discord.com/channels/478735028319158273/646375854628405273/1018920269190021180

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots/Screencaps

https://www.loom.com/share/dfd786087ce3402ab8b0bffc824166ad


