### PR TITLE
Fixes pubkey issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.2.0
+
+Uses a better `Wallet` implementation so that, for example, the user is asked less for their public key via a MetaMask popup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative-walletauth",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative-walletauth",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative-walletauth",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Use the [Webnative SDK](https://github.com/fission-codes/webnative#readme) with a blockchain wallet. Access your personal encrypted file system with your wallet keys.",
   "scripts": {
     "build": "npm run build:lib && npm run build:bundle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative-walletauth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Use the [Webnative SDK](https://github.com/fission-codes/webnative#readme) with a blockchain wallet. Access your personal encrypted file system with your wallet keys.",
   "scripts": {
     "build": "npm run build:lib && npm run build:bundle",

--- a/src/components/manners/implementation/base.ts
+++ b/src/components/manners/implementation/base.ts
@@ -1,4 +1,4 @@
-import * as Manners from "webnative/components/manners/implementation"
+import { Manners, Storage } from "webnative"
 
 import * as FileSystem from "webnative/fs/types"
 import * as FileSystemProtocol from "webnative/fs/protocol/basic"
@@ -24,6 +24,7 @@ export const READ_KEY_PATH = Path.file(Path.Branch.Public, ".well-known", "read-
 
 
 export async function implementation(
+  storage: Storage.Implementation,
   wallet: Wallet.Implementation,
   opts: Manners.ImplementationOptions
 ): Promise<Manners.Implementation> {
@@ -45,7 +46,7 @@ export async function implementation(
 
           await fs.write(
             READ_KEY_PATH,
-            await wallet.encrypt(readKey)
+            await wallet.encrypt(storage, readKey)
           )
 
           return base.fileSystem.hooks.afterLoadNew(fs, account, dataComponents)

--- a/src/wallet/common.ts
+++ b/src/wallet/common.ts
@@ -1,4 +1,4 @@
-import * as Crypto from "webnative/components/crypto/implementation"
+import { Crypto, Storage } from "webnative"
 import { publicKeyToDid } from "webnative/did/index"
 
 import * as Wallet from "./implementation.js"
@@ -6,8 +6,9 @@ import * as Wallet from "./implementation.js"
 
 export async function did(
   crypto: Crypto.Implementation,
+  storage: Storage.Implementation,
   wallet: Wallet.Implementation
 ): Promise<string> {
-  const pubKey = await wallet.publicSignatureKey()
-  return publicKeyToDid(crypto, pubKey.key, pubKey.type)
+  const pubKey = await wallet.publicSignature.key(storage)
+  return publicKeyToDid(crypto, pubKey, wallet.publicSignature.type)
 }

--- a/src/wallet/implementation.ts
+++ b/src/wallet/implementation.ts
@@ -1,7 +1,10 @@
+import { Storage } from "webnative"
+
+
 export type Implementation = {
   decrypt: (encryptedMessage: Uint8Array) => Promise<Uint8Array>
-  encrypt: (data: Uint8Array) => Promise<Uint8Array>
-  init: (args: InitArgs) => Promise<void>
+  encrypt: (storage: Storage.Implementation, data: Uint8Array) => Promise<Uint8Array>
+  init: (storage: Storage.Implementation, args: InitArgs) => Promise<void>
 
   /**
    * Properties of the key used for signing.
@@ -18,11 +21,15 @@ export type Implementation = {
    * Key type: "ed25519"
    * Magic bytes: [ 0xed, 0x01 ]
    */
-  publicSignatureKey: () => Promise<{ type: string, magicBytes: Uint8Array, key: Uint8Array }>
+  publicSignature: {
+    type: string
+    magicBytes: Uint8Array
+    key: (storage: Storage.Implementation) => Promise<Uint8Array>
+  }
   sign: (data: Uint8Array) => Promise<Uint8Array>
   ucanAlgorithm: string
   username: () => Promise<string>
-  verifySignedMessage: (args: VerifyArgs) => Promise<boolean>
+  verifySignedMessage: (storage: Storage.Implementation, args: VerifyArgs) => Promise<boolean>
 }
 
 

--- a/src/wallet/implementation/ethereum.ts
+++ b/src/wallet/implementation/ethereum.ts
@@ -4,6 +4,7 @@ import type { Implementation, InitArgs } from "../implementation.js"
 import * as nacl from "tweetnacl"
 import * as secp from "@noble/secp256k1"
 import * as uint8arrays from "uint8arrays"
+import { Maybe, Storage } from "webnative"
 import { keccak_256 } from "@noble/hashes/sha3"
 import Provider from "eip1193-provider"
 
@@ -36,8 +37,6 @@ export const SECP_PREFIX = new Uint8Array([ 0xe7, 0x01 ])
 
 let didBindEvents = false
 let globCurrentAccount: string | null = null
-let globPublicEncryptionKey: Uint8Array | null = null
-let globPublicSignatureKey: Uint8Array | null = null
 let provider: Provider | null = hasProp(self, "ethereum") ? self.ethereum as Provider : null
 
 
@@ -77,8 +76,8 @@ export async function decrypt(encryptedMessage: Uint8Array): Promise<Uint8Array>
 }
 
 
-export async function encrypt(data: Uint8Array): Promise<Uint8Array> {
-  const encryptionPublicKey = await publicEncryptionKey()
+export async function encrypt(storage: Storage.Implementation, data: Uint8Array): Promise<Uint8Array> {
+  const encryptionPublicKey = await publicEncryptionKey(storage)
 
   // Generate ephemeral keypair
   const ephemeralKeyPair = nacl.box.keyPair()
@@ -114,7 +113,10 @@ export async function encrypt(data: Uint8Array): Promise<Uint8Array> {
 }
 
 
-export async function init({ onAccountChange, onDisconnect }: InitArgs): Promise<void> {
+export async function init(
+  storage: Storage.Implementation,
+  { onAccountChange, onDisconnect }: InitArgs
+): Promise<void> {
   if (didBindEvents) return
 
   const ethereum = await load()
@@ -127,11 +129,13 @@ export async function init({ onAccountChange, onDisconnect }: InitArgs): Promise
       // MetaMask can sometimes trigger accountsChanged when first connecting to an account, so we need to
       // ensure it is actually being triggered by a new account change to avoid extra signatures
       if (globCurrentAccount !== accounts[ 0 ]) {
+        await clearCache(storage)
         handleAccountsChanged(accounts)
         await onAccountChange()
       }
     } else {
       // disconnected
+      await clearCache(storage)
       await disconnect({ onDisconnect })
     }
   })
@@ -139,6 +143,7 @@ export async function init({ onAccountChange, onDisconnect }: InitArgs): Promise
   // The MetaMask provider emits this event if it becomes unable to submit RPC requests to any chain.
   // In general, this will only happen due to network connectivity issues or some unforeseen error.
   ethereum.on("disconnect", async () => {
+    await clearCache(storage)
     await disconnect({ onDisconnect })
   })
 
@@ -146,19 +151,26 @@ export async function init({ onAccountChange, onDisconnect }: InitArgs): Promise
 }
 
 
-export async function publicSignatureKey(): Promise<{ type: string, magicBytes: Uint8Array, key: Uint8Array }> {
-  if (!globPublicSignatureKey) {
-    const signature = await sign(MSG_TO_SIGN)
-    const signatureParts = deconstructSignature(signature)
+export async function publicSignatureKey(storage: Storage.Implementation): Promise<Uint8Array> {
+  const cache = await fromCache(storage, CACHE_KEYS.PUBLIC_SIGNATURE_KEY)
+  if (cache) return uint8arrays.fromString(cache, "base64pad")
 
-    globPublicSignatureKey = secp.recoverPublicKey(
-      hashMessage(MSG_TO_SIGN),
-      signatureParts.full,
-      signatureParts.recoveryParam
-    )
-  }
+  const signature = await sign(MSG_TO_SIGN)
+  const signatureParts = deconstructSignature(signature)
 
-  return { type: KEY_TYPE, magicBytes: SECP_PREFIX, key: globPublicSignatureKey }
+  const pubKey = secp.recoverPublicKey(
+    hashMessage(MSG_TO_SIGN),
+    signatureParts.full,
+    signatureParts.recoveryParam
+  )
+
+  await toCache(
+    storage,
+    CACHE_KEYS.PUBLIC_SIGNATURE_KEY,
+    uint8arrays.toString(pubKey, "base64pad")
+  )
+
+  return pubKey
 }
 
 
@@ -186,13 +198,14 @@ export function username(): Promise<string> {
 
 
 export async function verifySignedMessage(
+  storage: Storage.Implementation,
   { signature, message, publicKey }:
     { signature: Uint8Array; message: Uint8Array; publicKey?: Uint8Array }
 ): Promise<boolean> {
   return secp.verify(
     deconstructSignature(signature).full,
     hashMessage(message),
-    publicKey || await publicSignatureKey().then(a => a.key)
+    publicKey || await publicSignatureKey(storage)
   )
 }
 
@@ -231,8 +244,9 @@ export function load(): Promise<Provider> {
 }
 
 
-export async function publicEncryptionKey(): Promise<Uint8Array> {
-  if (globPublicEncryptionKey) return globPublicEncryptionKey
+export async function publicEncryptionKey(storage: Storage.Implementation): Promise<Uint8Array> {
+  const cache = await fromCache(storage, CACHE_KEYS.PUBLIC_ENCRYPTION_KEY)
+  if (cache) return uint8arrays.fromString(cache, "base64pad")
 
   const ethereum = await load()
   const account = await address()
@@ -253,8 +267,8 @@ export async function publicEncryptionKey(): Promise<Uint8Array> {
     throw new Error("Expected ethereumPublicKey to be a string")
   }
 
-  globPublicEncryptionKey = uint8arrays.fromString(key, "base64pad")
-  return globPublicEncryptionKey
+  await toCache(storage, CACHE_KEYS.PUBLIC_ENCRYPTION_KEY, key)
+  return uint8arrays.fromString(key, "base64pad")
 }
 
 
@@ -364,11 +378,11 @@ export function uint8ArrayToEthereumHex(data: Uint8Array): string {
 // 🔬
 
 
-export async function verifyPublicKey(): Promise<boolean> {
-  return verifySignedMessage({
+export async function verifyPublicKey(storage: Storage.Implementation): Promise<boolean> {
+  return verifySignedMessage(storage, {
     signature: await sign(MSG_TO_SIGN),
     message: MSG_TO_SIGN,
-    publicKey: await publicSignatureKey().then(a => a.key),
+    publicKey: await publicSignatureKey(storage),
   })
 }
 
@@ -389,6 +403,44 @@ function handleAccountsChanged(accounts: unknown) {
 
 
 
+// ㊙️  –  CACHE
+
+
+export const STORAGE_KEYS = {
+  PUBLIC_ENCRYPTION_KEY: "wallet/public-encryption-key",
+  PUBLIC_SIGNATURE_KEY: "wallet/public-signature-key"
+}
+
+export const CACHE_KEYS: Record<CacheKey, CacheKey> = {
+  PUBLIC_ENCRYPTION_KEY: "PUBLIC_ENCRYPTION_KEY",
+  PUBLIC_SIGNATURE_KEY: "PUBLIC_SIGNATURE_KEY"
+}
+
+type CacheKey = keyof typeof STORAGE_KEYS
+
+
+async function clearCache(storage: Storage.Implementation): Promise<void> {
+  await Promise.all(
+    Object.keys(STORAGE_KEYS).map(key => {
+      return storage.removeItem(key)
+    })
+  )
+}
+
+
+async function fromCache(storage: Storage.Implementation, prop: CacheKey): Promise<Maybe<string>> {
+  const item = await storage.getItem(STORAGE_KEYS[ prop ])
+  if (typeof item === "string") return item
+  return null
+}
+
+
+async function toCache(storage: Storage.Implementation, prop: CacheKey, value: string): Promise<void> {
+  await storage.setItem(STORAGE_KEYS[ prop ], value)
+}
+
+
+
 // 🛳
 
 
@@ -396,7 +448,11 @@ export const implementation: Implementation = {
   decrypt,
   encrypt,
   init,
-  publicSignatureKey,
+  publicSignature: {
+    type: KEY_TYPE,
+    magicBytes: SECP_PREFIX,
+    key: publicSignatureKey
+  },
   sign,
   ucanAlgorithm: "ES256K",
   username,


### PR DESCRIPTION
Closes #14 

I asked for the public signature key every time we created the crypto component (ie. every time we created a program). I've removed that code and moved things around a bit so that it doesn't ask for the actual anymore. This now also caches both public keys in the storage component from Webnative, and clears the cache when the account disconnects or changes. A potential additional improvement here could be to not clear the cache and namespace the cache by the Ethereum address, but not sure if we should do that. Thoughts?