### PR TITLE
Fix: add await to RootKey.store

### DIFF
--- a/src/components/manners/implementation/base.ts
+++ b/src/components/manners/implementation/base.ts
@@ -73,7 +73,7 @@ export async function implementation(
           const encryptedRootKey = readKeyChild.content
           const rootKey = await wallet.decrypt(encryptedRootKey)
 
-          RootKey.store({
+          await RootKey.store({
             crypto: crypto,
             accountDID: account.rootDID,
             readKey: rootKey


### PR DESCRIPTION
# Description

I noticed a typescript error where the `RootKey.store` in `beforeLoadExisting` was not being `await`ed. This may have been causing some race conditions or inconsistencies when loading the file system

## Link to issue

N/A

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Screenshots/Screencaps

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/1179291/213526046-39d34eb9-504b-479c-8b3c-2fabd0f9f2ab.png">