### PR TITLE
Feat: bump webnative to v0.36.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "^4.5.5"
       },
       "peerDependencies": {
-        "webnative": "^0.35.0"
+        "webnative": "^0.36.3"
       }
     },
     "node_modules/@chainsafe/is-ip": {
@@ -3664,9 +3664,9 @@
       "peer": true
     },
     "node_modules/webnative": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.0.tgz",
-      "integrity": "sha512-Simk76/VMLmet+KvFXe3msTw69zQt0n7kx+dE9yauITkyrRlAyPOO88yaPb8gBXCRmcQkFMAffJIPL21vZ/u5Q==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.3.tgz",
+      "integrity": "sha512-MucN6ydnyY5E8GczuARAWXSOn3+yjXKSLNTIPeJhcFmZpxPBDRfpZ0SpKJjKWtVLNiEaUQibeiKsIYDfij/wIQ==",
       "peer": true,
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
@@ -6343,9 +6343,9 @@
       "peer": true
     },
     "webnative": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.0.tgz",
-      "integrity": "sha512-Simk76/VMLmet+KvFXe3msTw69zQt0n7kx+dE9yauITkyrRlAyPOO88yaPb8gBXCRmcQkFMAffJIPL21vZ/u5Q==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.3.tgz",
+      "integrity": "sha512-MucN6ydnyY5E8GczuARAWXSOn3+yjXKSLNTIPeJhcFmZpxPBDRfpZ0SpKJjKWtVLNiEaUQibeiKsIYDfij/wIQ==",
       "peer": true,
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative-walletauth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Use the [Webnative SDK](https://github.com/fission-codes/webnative#readme) with a blockchain wallet. Access your personal encrypted file system with your wallet keys.",
   "scripts": {
     "build": "npm run build:lib && npm run build:bundle",
@@ -60,7 +60,7 @@
   },
   "homepage": "https://github.com/fission-codes/webnative-walletauth#readme",
   "peerDependencies": {
-    "webnative": "^0.35.0"
+    "webnative": "^0.36.3"
   },
   "dependencies": {
     "@noble/hashes": "^1.1.2",

--- a/src/components/manners/implementation/base.ts
+++ b/src/components/manners/implementation/base.ts
@@ -16,7 +16,7 @@ import * as Wallet from "../../../wallet/implementation.js"
 // 🏔
 
 
-export const READ_KEY_PATH = Path.file(Path.Branch.Public, ".well-known", "read-key")
+export const READ_KEY_PATH = Path.file("public", ".well-known", "read-key")
 
 
 


### PR DESCRIPTION
# Description

- Bump `webnative` peer dependency to `0.36.3`
- Replace `Path.Branch.Public` in `READ_KEY_PATH` with `public`

[walletauth PR](https://github.com/webnative-examples/walletauth/pull/16) to test these changes. 

When testing this initially I was seeing a `Signature does not match content` error any time I tried to `publish` something to the file system, but the error seems to be resolved now... so i'm not sure if it was an issue with the Fission server, but everything seems to be working now 🤔 

## Link to issue

https://github.com/orgs/fission-codes/projects/14/views/26?pane=issue&itemId=21175565

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)
